### PR TITLE
add default value parameter which defaults to NULL

### DIFF
--- a/classes/DotEnv.php
+++ b/classes/DotEnv.php
@@ -92,11 +92,11 @@ final class DotEnv
         return self::$singleton->isLoaded();
     }
 
-    public static function getenv(string $env)
+    public static function getenv(string $env, mixed $default = null)
     {
         if (! self::$singleton) {
             self::load();
         }
-        return A::get($_ENV, $env, null);
+        return A::get($_ENV, $env, $default);
     }
 }

--- a/global.php
+++ b/global.php
@@ -11,8 +11,8 @@ if (! function_exists('loadenv')) {
 }
 
 if (! function_exists('env')) {
-    function env(string $env)
+    function env(string $env, mixed $default = null)
     {
-        return \Bnomei\DotEnv::getenv($env);
+        return \Bnomei\DotEnv::getenv($env, $default);
     }
 }

--- a/index.php
+++ b/index.php
@@ -17,19 +17,19 @@ Kirby::plugin('bnomei/dotenv', [
         }
     ],
     'pageMethods' => [
-        'env' => function (string $env) {
-            return \Bnomei\DotEnv::getenv($env);
+        'env' => function (string $env, mixed $default = null) {
+            return \Bnomei\DotEnv::getenv($env, $default);
         },
-        'getenv' => function (string $env) {
-            return \Bnomei\DotEnv::getenv($env);
+        'getenv' => function (string $env, mixed $default = null) {
+            return \Bnomei\DotEnv::getenv($env, $default);
         },
     ],
     'siteMethods' => [
-        'env' => function (string $env) {
-            return \Bnomei\DotEnv::getenv($env);
+        'env' => function (string $env, mixed $default = null) {
+            return \Bnomei\DotEnv::getenv($env, $default);
         },
-        'getenv' => function (string $env) {
-            return \Bnomei\DotEnv::getenv($env);
+        'getenv' => function (string $env, mixed $default = null) {
+            return \Bnomei\DotEnv::getenv($env, $default);
         },
     ],
 ]);


### PR DESCRIPTION
This PR adds an additional `default` parameter to the given get-Methods (e.g. env) which makes handling of non-existing parameters more readable.